### PR TITLE
add backlinks to report docs + consistentify!

### DIFF
--- a/reports/detailed.md
+++ b/reports/detailed.md
@@ -1,15 +1,17 @@
 #Detailed report#
 
 The detailed report returns the time entries for the requested parameters/filters.
-There is one additional parameter in detailed reports. As the returned data is paginated you have to add the page parameter.
-* page: integer, default 1
+
+##Request##
+
+In addition to the [standard request parameters](../reports.md#request-parameters), there is one additional parameter in detailed reports. As the returned data is paginated you have to add the page parameter.
+* `page`: integer, default 1
 
 ##Response##
 
-General data
-* total_count: total number of time entries that were found for the request. Pay attention to the fact that the amount of time entries returned is max the number which is returned with the `per_page` field (currently 50). To get the next batch of time entries you need to do a new request with same parameters and the incremented `page` parameter. It is not possible to get all the time entries with one request.
-* per_page: how many time entries are displayed in one request
-
+The repsonse will include the [standard response parameters](../reports.md#successful-response), as well as:
+* `total_count`: total number of time entries that were found for the request. Pay attention to the fact that the amount of time entries returned is max the number which is returned with the `per_page` field (currently 50). To get the next batch of time entries you need to do a new request with same parameters and the incremented `page` parameter. It is not possible to get all the time entries with one request.
+* `per_page`: how many time entries are displayed in one request
 
 ###Data array###
 

--- a/reports/summary.md
+++ b/reports/summary.md
@@ -1,11 +1,14 @@
 #Summary report#
 
 Summary report returns the aggregated time entries data.
-Additional parameters for this report
-* grouping
-* subgrouping
-* subgrouping_ids (boolean) - whether returned items will contain 'ids' key containing coma separated group item ID values
-* grouped_time_entry_ids (boolean) - whether returned items will contain 'time_entry_ids' key containing coma separated time entries ID values for given item
+
+##Request##
+
+In addition to the [standard request parameters](../reports.md#request-parameters), summaries accept the following additional parameters:
+* `grouping`
+* `subgrouping`
+* `subgrouping_ids` (boolean) - whether returned items will contain 'ids' key containing coma separated group item ID values
+* `grouped_time_entry_ids` (boolean) - whether returned items will contain 'time_entry_ids' key containing coma separated time entries ID values for given item
 
 Use the grouping and subgrouping params to organize the data as needed. By default `grouping:projects` and `subgrouping:time_entries`
 
@@ -26,6 +29,8 @@ Following groupings with subgroupings are available in the summary report
   * clients
 
 ##Response##
+
+The repsonse will include the [standard response parameters](../reports.md#successful-response).
 
 ###Data array###
 

--- a/reports/weekly.md
+++ b/reports/weekly.md
@@ -1,16 +1,19 @@
 #Weekly report#
 
-The weekly report gives aggregated 7 day durations or earnings grouped by users and projects. The `until` parameter is ignored for weekly report, 7 days starting from since are shown.
+The weekly report gives aggregated 7 day durations or earnings grouped by users and projects.
 
-Additional parameters for this report are:
-* grouping: users/projects, default projects. If one grouping is selected, the other acts as subgrouping.
-* calculate: time/earnings, default time
+##Request##
 
+The weekly report accepts all of the [standard request parameters](../reports.md#request-parameters), with the exception of the `until` parameter.  Instead, 7 days starting from `since` are shown.
+
+Additional request parameters for this report are:
+* `grouping`: `users`/`projects`, default projects. If one grouping is selected, the other acts as subgrouping.
+* `calculate`: `time`/`earnings`, default time
 
 ##Response##
 
-General data
-* week_totals: array of total amounts/hours for every day (null if there's no work on a certain day)
+The repsonse will include the [standard response parameters](../reports.md#successful-response), as well as:
+* `week_totals`: array of total amounts/hours for every day (null if there's no work on a certain day)
 
 ###Data array###
 


### PR DESCRIPTION
```
* I am a dummy and it took me awhile to figure out that the standard
query parameters are listed in reports.md. This patch adds a
"Request" section to each report file that links backs to the
sandard request parameters in reports.md.  It also adds links back
to the standard response parameters.
```

This PR supercedes my previous PR, so I shall close it.

Thank you!
Fitz Elliott
