### PR TITLE
Updated readme with link to Elixir wrapper library

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The Toggl API has moved to Github so you could actively participate in helping u
 ### PHP ###
 * [Arend Jan Tetteroo](https://github.com/arendjantetteroo) has written a library for PHP for Toggl API v8, based on the excellent Guzzle library: https://github.com/arendjantetteroo/guzzle-toggl
 
+### Elixir ###
+
+* [Víctor Viruete](https://github.com/hopsor) has written an Elixir wrapper for Toggl API v8 and Reports API: https://github.com/diacode/togglex
+
 ##3rd party apps##
 * [Federico Vaga](https://github.com/FedericoVaga) has written a little plasmoid for KDE: https://github.com/FedericoVaga/plasmoggl (on opendesktop: http://opendesktop.org/content/show.php/Plasmoggl?content=168536)
 


### PR DESCRIPTION
Yesterday we released on [hex.pm](https://hex.pm/packages/togglex) this Elixir wrapper for Toggl v8 and Reports API. There still are some features pending to implement although most of both of them are already covered. The status of the features can be followed [here](https://github.com/diacode/togglex#features)