### PR TITLE
Improve clarity of authentication

### DIFF
--- a/reports.md
+++ b/reports.md
@@ -31,7 +31,7 @@ limits set upon token/IP combination.
 ##Authentication##
 
 You can authenticate in the reports API **only** with your API token. For HTTP Basic Auth you have to add the Authorization header with the request.
-The token is sent as user name and the string 'api_token' as the password.
+The API token is the user name and the string 'api_token' is the password.
 Whenever possible please use the tools and interfaces provided by your http library to do Basic Auth (for example, curl uses the -u switch for that).
 
 ##Request Parameters##


### PR DESCRIPTION
When I first came to this section, I read "token" in the 3rd sentence as being the value of the Authorization header, and created a header value of "<username>:api_token". I've tried to re-word it slightly so that it is clearer that it should be "<api_token>:api_token".