### PR TITLE
Fixed typo of 'toggle' in Python section to 'Toggl'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Toggl API has moved to Github so you could actively participate in helping u
 * [Mikhail Novikov](https://github.com/kurtgn) has created a graphical utility for displaying historical data: https://github.com/kurtgn/chronicl
 * [Robert Adams](https://github.com/drobertadams) and [Beau Raines](https://github.com/beauraines) have updated [toggl-cli](https://github.com/drobertadams/toggl-cli) to API v8. It provides a set of Python objects for interacting with Toggl, as well as a command-line interface: https://github.com/drobertadams/toggl-cli
 * [Matthew Downey](https://github.com/matthewdowney) has started a Toggl API wrapper: https://github.com/matthewdowney/TogglPy
-* [Matthias Büchi](https://github.com/ynop) has created a simple tool to calculate the difference between the tracked hours in toggle and the hours one should work in a given period: https://github.com/ynop/togglore
+* [Matthias Büchi](https://github.com/ynop) has created a simple tool to calculate the difference between the tracked hours in Toggl and the hours one should work in a given period: https://github.com/ynop/togglore
 * [David Cako](https://github.com/david-cako) has written an efficient command line interface for inputting time-insensitive toggl entries: https://github.com/david-cako/toggl-hammer
 
 ### Ruby ###


### PR DESCRIPTION
In the Python API section, the app Toggl was referred to as toggle. I have fixed this spelling error.