### PR TITLE
Update users properties list

### DIFF
--- a/chapters/users.md
+++ b/chapters/users.md
@@ -5,14 +5,15 @@ User has the following properties
 * api_token: (string)
 * default_wid: default workspace id (integer)
 * email: (string)
+* fullname: (string)
 * jquery_timeofday_format: (string)
-* jquery_date_format:(string)
+* jquery_date_format: (string)
 * timeofday_format: (string)
 * date_format: (string)
 * store_start_and_stop_time: whether start and stop time are saved on time entry (boolean)
 * beginning_of_week: (integer 0-6, Sunday=0)
 * language: user's language (string)
-* image_url: url with the user's profile picture(string)
+* image_url: url with the user's profile picture (string)
 * sidebar_piechart: should a piechart be shown on the sidebar (boolean)
 * at: timestamp of last changes
 * new_blog_post: an object with toggl blog post title and link


### PR DESCRIPTION
_fullname_ was missing in the properties overview.

* Insert fullname like listed in the example responses,
* Insert some missing spaces.
___
Unfortunately the list is still missing a short info, whether a field is required or not, like in the other chapters. Would'nt it make sense to include that?