### PR TITLE
Fix markdown formatting of headers

### DIFF
--- a/chapters/authentication.md
+++ b/chapters/authentication.md
@@ -83,7 +83,7 @@ Response
 
 ```
 
-##HTTP Basic Auth with API token##
+## HTTP Basic Auth with API token ##
 When using Basic Auth and API token, use the API token as username and string "api_token" as password.
 
 Example request

--- a/chapters/clients.md
+++ b/chapters/clients.md
@@ -7,7 +7,7 @@ Client has the following properties
 * notes: Notes for the client (string, not required)
 * at: timestamp that is sent in the response, indicates the time client was last updated
 
-##Create a client##
+## Create a client ##
 
 `POST https://www.toggl.com/api/v8/clients`
 
@@ -33,7 +33,7 @@ Successful response
 }
 ```
 
-##Get client details##
+## Get client details ##
 
 `GET https://www.toggl.com/api/v8/clients/{client_id}`
 
@@ -58,7 +58,7 @@ Successful response
 }
 ```
 
-##Update a client##
+## Update a client ##
 `PUT https://www.toggl.com/api/v8/clients/{client_id}`
 
 Workspace id (wid) can't be changed.
@@ -84,7 +84,7 @@ Successful response
 }
 ```
 
-##Delete a client##
+## Delete a client ##
 
 `DELETE https://www.toggl.com/api/v8/clients/{client_id}`
 
@@ -97,12 +97,12 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
 
 
-##Get workspace clients##
+## Get workspace clients ##
 
 Retrieving workspace clients is documented [here](workspaces.md#get-workspace-clients).
 
 
-##Get clients visible to user##
+## Get clients visible to user ##
 
 `GET https://www.toggl.com/api/v8/clients`
 
@@ -131,7 +131,7 @@ Successful response is an array of clients
 ]
 ```
 
-##Get client projects##
+## Get client projects ##
 
 `GET https://www.toggl.com/api/v8/clients/{client_id}/projects`
 

--- a/chapters/cors.md
+++ b/chapters/cors.md
@@ -8,8 +8,8 @@ A CORS whitelist record has the following properties
 
 Record id (id) can't be changed on update.
 
-##Actions##
-###Create an entry###
+## Actions ##
+### Create an entry ###
 
 `POST https://www.toggl.com/api/v9/me/cors`
 
@@ -32,7 +32,7 @@ Successful response
 }
 ```
 
-###Get entries for current user###
+### Get entries for current user ###
 
 `GET https://www.toggl.com/api/v9/me/cors`
 
@@ -64,7 +64,7 @@ Successful response
 ]
 ```
 
-###Delete an entry###
+### Delete an entry ###
 
 `DELETE https://www.toggl.com/api/v9/me/cors/{id}`
 

--- a/chapters/dashboard.md
+++ b/chapters/dashboard.md
@@ -20,7 +20,7 @@ Most active user object has the following properties
 * user_id: user ID
 * duration: Sum of time entry durations that have been created during last 7 days
 
-##Get Dashboard data##
+## Get Dashboard data ##
 
 `GET https://www.toggl.com/api/v8/dashboard/{workspace_id}`
 

--- a/chapters/groups.md
+++ b/chapters/groups.md
@@ -6,7 +6,7 @@ Group has the following properties
 * wid: workspace ID, where the group will be used (integer, required)
 * at: timestamp that is sent in the response, indicates the time group was last updated
 
-##Create a group##
+## Create a group ##
 
 `POST https://www.toggl.com/api/v8/groups`
 
@@ -32,7 +32,7 @@ Successful response
 }
 ```
 
-##Update a group##
+## Update a group ##
 `PUT https://www.toggl.com/api/v8/groups/{group_id}`
 
 Workspace id (wid) can't be changed.
@@ -57,7 +57,7 @@ Successful response
 }
 ```
 
-##Delete a group##
+## Delete a group ##
 
 `DELETE https://www.toggl.com/api/v8/groups/{group_id}`
 
@@ -70,6 +70,6 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
 
 
-##Get workspace groups##
+## Get workspace groups ##
 
 Retrieving workspace groups is documented [here](workspaces.md#get-workspace-groups).

--- a/chapters/project_users.md
+++ b/chapters/project_users.md
@@ -11,15 +11,15 @@ Project user has the following properties
 Workspace id (wid), project id (pid) and user id (uid) can't be changed on update.
 
 
-###Additional fields###
+### Additional fields ###
 It's possible to get user's fullname. For that you have to send the `fields` parameter in request with desired property name.
 
 * fullname: full name of the user, who is added to the project
 
 
-##Actions for single project user##
+## Actions for single project user ##
 
-###Create a project user###
+### Create a project user ###
 
 `POST https://www.toggl.com/api/v8/project_users`
 
@@ -49,7 +49,7 @@ Successful response
 ```
 
 
-###Update a project user###
+### Update a project user ###
 
 `PUT https://www.toggl.com/api/v8/project_users/{project_user_id}`
 
@@ -79,7 +79,7 @@ Successful response
 }
 ```
 
-###Delete a project user###
+### Delete a project user ###
 
 `DELETE https://www.toggl.com/api/v8/project_users/{project_user_id}`
 
@@ -92,9 +92,9 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
 
 
-##Mass Actions##
+## Mass Actions ##
 
-###Get list of project users in a Workspace###
+### Get list of project users in a Workspace ###
 ```shell
 curl -v -u TOKEN:api_token https://www.toggl.com/api/v8/workspaces/{workspace_id}/project_users
 ```
@@ -102,7 +102,7 @@ curl -v -u TOKEN:api_token https://www.toggl.com/api/v8/workspaces/{workspace_id
 Successful request will return a list of all project users in the workspace.
 Note: Does not support the `fields` parameter (hence a `fullname` field won't be returned)
 
-###Create multiple project users for single project###
+### Create multiple project users for single project ###
 To create multiple project users for a single project, you must add multiple user ids separated with a comma with the `uid` parameter.
 
 `POST https://www.toggl.com/api/v8/project_users`
@@ -148,7 +148,7 @@ Successful response is an array of project_users.
 
 ```
 
-###Mass update for project users###
+### Mass update for project users ###
 
 By supplying multiple project user ids, you can mass update project users.
 `PUT https://www.toggl.com/api/v8/project_users/{project_user_ids}`
@@ -195,7 +195,7 @@ Successful response is an array of project_users.
 }
 ```
 
-###Delete multiple project users###
+### Delete multiple project users ###
 
 By supplying multiple project user ids, you can mass delete project users.
 `DELETE https://www.toggl.com/api/v8/project_users/{project_user_ids}`

--- a/chapters/projects.md
+++ b/chapters/projects.md
@@ -18,7 +18,7 @@ Project has the following properties
 * at: timestamp indicating when the project was created (UTC time), read-only
 
 
-##Create project##
+## Create project ##
 
 `POST https://www.toggl.com/api/v8/projects`
 
@@ -49,7 +49,7 @@ Successful response
 }
 ```
 
-##Get project data##
+## Get project data ##
 
 `GET https://www.toggl.com/api/v8/projects/{project_id}`
 
@@ -79,7 +79,7 @@ Successful response
 }
 ```
 
-##Update project data##
+## Update project data ##
 
 `PUT https://www.toggl.com/api/v8/projects/{project_id}`
 
@@ -110,7 +110,7 @@ Successful response
 }
 ```
 
-##Delete a project##
+## Delete a project ##
 
 `DELETE https://www.toggl.com/api/v8/projects/{project_id}`
 
@@ -120,7 +120,7 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-X DELETE https://www.toggl.com/api/v8/projects/4692190
 ```
 
-##Get project users##
+## Get project users ##
 
 `GET https://www.toggl.com/api/v8/projects/{project_id}/project_users`
 Read more about project user fields from [here](project_users.md).
@@ -155,7 +155,7 @@ Successful response is an array of the project's users
 ]
 ```
 
-##Get project tasks##
+## Get project tasks ##
 Available only for pro workspaces
 
 `GET https://www.toggl.com/api/v8/projects/{project_id}/tasks`
@@ -192,14 +192,14 @@ Successful response is an array of the project's tasks
 ]
 ```
 
-##Get workspace projects##
+## Get workspace projects ##
 
 Retrieving workspace projects is documented [here](workspaces.md#get-workspace-projects).
 
 
-##Mass Actions##
+## Mass Actions ##
 
-###Delete multiple projects###
+### Delete multiple projects ###
 
 By supplying multiple projectuser ids, you can mass delete projects.
 `DELETE https://www.toggl.com/api/v8/projects/{project_ids}`

--- a/chapters/tags.md
+++ b/chapters/tags.md
@@ -5,7 +5,7 @@ Tag has the following properties
 * name: The name of the tag (string, required, unique in workspace)
 * wid: workspace ID, where the tag will be used (integer, required)
 
-##Create tag##
+## Create tag ##
 
 `POST https://www.toggl.com/api/v8/tags`
 
@@ -30,7 +30,7 @@ Successful response
 }
 ```
 
-##Update a tag##
+## Update a tag ##
 `PUT https://www.toggl.com/api/v8/tags/{tag_id}`
 
 Workspace id (wid) can't be changed.
@@ -54,7 +54,7 @@ Successful response
 }
 ```
 
-##Delete a tag##
+## Delete a tag ##
 
 `DELETE https://www.toggl.com/api/v8/tags/{tag_id}`
 

--- a/chapters/tasks.md
+++ b/chapters/tasks.md
@@ -14,8 +14,8 @@ Task has the following properties
 
 Workspace id (wid) and project id (pid) can't be changed on update.
 
-##Actions for single project user##
-###Create a task###
+## Actions for single project user ##
+### Create a task ###
 
 `POST https://www.toggl.com/api/v8/tasks`
 
@@ -43,7 +43,7 @@ Successful response
 }
 ```
 
-###Get task details###
+### Get task details ###
 
 `GET https://www.toggl.com/api/v8/tasks/{task_id}`
 
@@ -68,7 +68,7 @@ Successful response
 }
 ```
 
-###Update a task###
+### Update a task ###
 
 `PUT https://www.toggl.com/api/v8/tasks/{task_id}`
 
@@ -97,7 +97,7 @@ Successful response
 }
 ```
 
-###Delete a task###
+### Delete a task ###
 
 `DELETE https://www.toggl.com/api/v8/tasks/{task_id}`
 
@@ -109,9 +109,9 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
 
-##Mass Actions##
+## Mass Actions ##
 
-###Update multiple tasks###
+### Update multiple tasks ###
 
 By supplying multiple task ids, you can mass update tasks. This is good for marking tasks as done or not done (`active`).
 
@@ -153,7 +153,7 @@ Successful response is an array of tasks.
 }
 ```
 
-###Delete multiple tasks###
+### Delete multiple tasks ###
 By supplying multiple task ids, you can mass delete tasks.
 `DELETE https://www.toggl.com/api/v8/tasks/{task_ids}`
 

--- a/chapters/time_entries.md
+++ b/chapters/time_entries.md
@@ -17,7 +17,7 @@ Time entry has the following properties
 * duronly: should Toggl show the start and stop time of this time entry? (boolean, not required)
 * at: timestamp that is sent in the response, indicates the time item was last updated
 
-##Create a time entry##
+## Create a time entry ##
 
 `POST https://www.toggl.com/api/v8/time_entries`
 
@@ -48,7 +48,7 @@ Successful response
 }
 ```
 
-##Start a time entry##
+## Start a time entry ##
 
 `POST https://www.toggl.com/api/v8/time_entries/start`
 
@@ -79,7 +79,7 @@ Successful response
 }
 ```
 
-##Stop a time entry##
+## Stop a time entry ##
 
 `PUT https://www.toggl.com/api/v8/time_entries/{time_entry_id}/stop`
 
@@ -107,7 +107,7 @@ Successful response
 }
 ```
 
-##Get time entry details##
+## Get time entry details ##
 
 `GET https://www.toggl.com/api/v8/time_entries/{time_entry_id}`
 
@@ -138,7 +138,7 @@ Successful response
 ```
 
 
-##Get running time entry##
+## Get running time entry ##
 
 `GET https://www.toggl.com/api/v8/time_entries/current`
 
@@ -166,7 +166,7 @@ Successful response
 ```
 
 
-##Update a time entry##
+## Update a time entry ##
 `PUT https://www.toggl.com/api/v8/time_entries/{time_entry_id}`
 
 Example request
@@ -198,7 +198,7 @@ Successful response
 }
 ```
 
-##Delete a time entry##
+## Delete a time entry ##
 
 
 `DELETE https://www.toggl.com/api/v8/time_entries/{time_entry_id}`
@@ -212,7 +212,7 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 Successful request will return `200 OK`
 
 
-##Get time entries started in a specific time range##
+## Get time entries started in a specific time range ##
 
 `GET https://www.toggl.com/api/v8/time_entries`
 

--- a/chapters/workspace_users.md
+++ b/chapters/workspace_users.md
@@ -8,7 +8,7 @@ Workspace user has the following properties:
 * active: if the workspace user has accepted the invitation to this workspace (boolean)
 * invite_url: if user has not accepted the invitation the url for accepting his/her invitation is sent when the request is made by workspace_admin
 
-##Invite users to workspace##
+## Invite users to workspace ##
 
 You can add users to workspace by email addresses. A letter inviting the user to your workspace is sent to the user's email.
 
@@ -48,7 +48,7 @@ Successful response
 ```
 
 
-##Update workspace user##
+## Update workspace user ##
 
 Only the admin flag can be changed.
 
@@ -77,7 +77,7 @@ Successful response
 }
 ```
 
-##Delete workspace user##
+## Delete workspace user ##
 
 `DELETE https://www.toggl.com/api/v8/workspace_users/{workspace_user_id}`
 
@@ -89,7 +89,7 @@ curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
 
-##Get workspace users##
+## Get workspace users ##
 
 This request returns not the user objects, but the `workspace_user` objects (the connection between user and workspace)
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/workspace_users`

--- a/chapters/workspaces.md
+++ b/chapters/workspaces.md
@@ -22,7 +22,7 @@ Workspace has the following properties
 | round up   | 1       |
 
 
-##Get workspaces##
+## Get workspaces ##
 
 `GET https://www.toggl.com/api/v8/workspaces`
 Get data about all the workspaces where the token owner belongs to.
@@ -65,7 +65,7 @@ Successful response is an array of workspaces
 ]
 ```
 
-##Get single workspace##
+## Get single workspace ##
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}`
 
 Example request
@@ -94,7 +94,7 @@ Successful response
 }
 ```
 
-##Update workspace##
+## Update workspace ##
 
 `PUT https://www.toggl.com/api/v8/workspaces/{workspace_id}`
 
@@ -129,7 +129,7 @@ Successful response
 }
 ```
 
-##Get workspace users##
+## Get workspace users ##
 
 To get a successful response, the token owner must be workspace admin.
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/users`
@@ -191,7 +191,7 @@ Successful response is an array of workspace users
 ]
 ```
 
-##Get workspace clients##
+## Get workspace clients ##
 
 To get a successful response, the token owner must be workspace admin.
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/clients`
@@ -225,7 +225,7 @@ Successful response is an array of workspace clients
 ]
 ```
 
-##Get workspace groups##
+## Get workspace groups ##
 
 To get a successful response, the token owner must be workspace admin.
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/groups`
@@ -253,7 +253,7 @@ Successful response is an array of workspace groups
 ]
 ```
 
-##Get workspace projects##
+## Get workspace projects ##
 
 To get a successful response, the token owner must be workspace admin.
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/projects`
@@ -298,7 +298,7 @@ Successful response is an array of active workspace projects
 ]
 ```
 
-##Get workspace tasks##
+## Get workspace tasks ##
 
 Available only for pro workspaces
 To get a successful response, the token owner must be workspace admin.
@@ -348,7 +348,7 @@ Successful response is an array of workspace tasks
 ]
 ```
 
-##Get workspace tags##
+## Get workspace tags ##
 
 `GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/tags`
 

--- a/reports.md
+++ b/reports.md
@@ -9,7 +9,7 @@ More detailed information for the reports.
 * [Summary report](reports/summary.md)
 * [Project dashboard](reports/project.md)
 
-##URLs##
+## URLs ##
 
 The reports API base URL is `https://toggl.com/reports/api/v2`
 
@@ -21,20 +21,20 @@ Summary report URL: `GET https://toggl.com/reports/api/v2/summary`
 
 For PDF response add .pdf to the end of the URL.
 
-##Rate limiting##
+## Rate limiting ##
 
 There is rate limiting of 1 request per second (per IP per API token), this
 limit may change in future. In case client application exceeds rate limit
 HTTP status 429 will be returned. Excessive requests may yield in stricter 
 limits set upon token/IP combination.
 
-##Authentication##
+## Authentication ##
 
 You can authenticate in the reports API **only** with your API token. For HTTP Basic Auth you have to add the Authorization header with the request.
 The API token is the user name and the string 'api_token' is the password.
 Whenever possible please use the tools and interfaces provided by your http library to do Basic Auth (for example, curl uses the -u switch for that).
 
-##Request Parameters##
+## Request Parameters ##
 
 The API expects the request parameters as the query string of the URL.
 
@@ -63,7 +63,7 @@ The following parameters and filters can be used in all of the reports
 * `rounding`: "on" or "off". Defaults to "off". Rounds time according to workspace settings.
 * `display_hours`: "decimal" or "minutes". Defaults to "minutes". Determines whether to display hours as a decimal number or with minutes.
 
-##Successful response##
+## Successful response ##
 
 The general structure of the successful response
 ```json
@@ -81,7 +81,7 @@ The response may include some additional attributes depending on the report type
 * total_currencies: an array with amounts and currencies for the selected report
 * data: an array with detailed information of the requested report. The structure of the data in the array depends on the report.
 
-##Failed requests##
+## Failed requests ##
 
 In case of unsuccessful request the API returns the error in JSON and corresponding HTTP status code
 * message: the general message of the occurred error

--- a/reports/project.md
+++ b/reports/project.md
@@ -1,8 +1,8 @@
-#Project dashboard#
+# Project dashboard #
 
 [Project dashboard](http://support.toggl.com/project-dashboard/) returns at-a glance information for a single project. This feature is only available with Toggl pro.
 
-##Request##
+## Request ##
 
 `GET /reports/api/v2/project`
  
@@ -19,7 +19,7 @@ Parameters are:
 * `order_desc` string:  on/off, `on` for descending and `off` for ascending 
 order
 
-##Response##
+## Response ##
 
 Project dashboard response has following strucure: ([json schema]
 (project_dashboard_schema.json))
@@ -65,7 +65,7 @@ Project dashboard response has following strucure: ([json schema]
 * `tasks_page` is array holding all tasks of given project, one page 
  at a time
 
-##Example##
+## Example ##
  
 request:
 ```shell

--- a/reports/summary.md
+++ b/reports/summary.md
@@ -1,8 +1,8 @@
-#Summary report#
+# Summary report #
 
 Summary report returns the aggregated time entries data.
 
-##Request##
+## Request ##
 
 In addition to the [standard request parameters](../reports.md#request-parameters), summaries accept the following additional parameters:
 * `grouping`
@@ -28,11 +28,11 @@ Following groupings with subgroupings are available in the summary report
   * projects
   * clients
 
-##Response##
+## Response ##
 
 The response will include the [standard response parameters](../reports.md#successful-response).
 
-###Data array###
+### Data array ###
 
 General structure of the item in the data array
 * id: the id of the grouping object
@@ -70,10 +70,10 @@ General structure of the item in the data array
   }
 ```
 
-##Project colors##
+## Project colors ##
 When grouped by project the title part of the return will contain color and color_hex fields. First one contains the color id (returned also by APIv8), second one will return the corresponding HEX value. (Please note: color return is a subject of change).
 
-##Example##
+## Example ##
 
 Example request
 ```shell

--- a/reports/weekly.md
+++ b/reports/weekly.md
@@ -1,8 +1,8 @@
-#Weekly report#
+# Weekly report #
 
 The weekly report gives aggregated 7 day durations or earnings grouped by users and projects.
 
-##Request##
+## Request ##
 
 The weekly report accepts all of the [standard request parameters](../reports.md#request-parameters), with the exception of the `until` parameter.  Instead, 7 days starting from `since` are shown.
 
@@ -10,12 +10,12 @@ Additional request parameters for this report are:
 * `grouping`: `users`/`projects`, default projects. If one grouping is selected, the other acts as subgrouping.
 * `calculate`: `time`/`earnings`, default time
 
-##Response##
+## Response ##
 
 The response will include the [standard response parameters](../reports.md#successful-response), as well as:
 * `week_totals`: array of total amounts/hours for every day (null if there's no work on a certain day)
 
-###Data array###
+### Data array ###
 
 Grouping is `projects` the main grouping looks like this
 * title: object containing project and client name
@@ -87,7 +87,7 @@ If `calculate=earnings`, it is an array of objects with currency string and the 
   ]
 ```
 
-##Example##
+## Example ##
 
 Example request
 ```shell

--- a/toggl_api.md
+++ b/toggl_api.md
@@ -6,11 +6,11 @@ If the time entry is currently running, the *duration* attribute contains a nega
 
 The result of each action is communicated via standard HTTP response codes.
 
-###CORS###
+### CORS ###
 
 If you wish to use the API using CORS, we'll need to whitelist you first. Please refer to the [CORS documentation](https://github.com/toggl/toggl_api_docs/blob/master/chapters/cors.md)
 
-###Successful requests###
+### Successful requests ###
 
 When request is successful (2xx), a nested response object is returned. Fields which value is NULL are not in the response.
 
@@ -43,7 +43,7 @@ Response
 }
 ```
 
-###Failed requests###
+### Failed requests ###
 
 If a create or update action failed, HTTP status code 404 and an array of localized error messages will be returned.
 
@@ -59,13 +59,13 @@ Response
 `["Start can't be blank"]`
 
 
-##Authentication##
+## Authentication ##
 
 To use the API, you need to authenticate yourself. This can be done via HTTP POST or HTTP Basic Auth. After successful authentication a session is created using a cookie.
 
 If authentication fails, HTTP status code 403 is returned. You can read more about authentication and see sample requests [here](chapters/authentication.md).
 
-##Supported API requests##
+## Supported API requests ##
 
 * [Authenticate and get user data](chapters/authentication.md)
  - HTTP Basic Auth with e-mail and password


### PR DESCRIPTION
These docs incorrectly formatted Markdown headers without a space between the # symbols and the header content. For example, headers previously looked like this:

```
##Get Dashboard data##
##Create project##
##Get project data##
```

I have updated the headers in all documents to reflect the formatting necessary for proper display of these documents on Github:

```
## Get Dashboard data ##
## Create project ##
## Get project data ##
```

Without this spacing, these headers render on Github like this...

![image](https://cloud.githubusercontent.com/assets/542937/25686321/51c75c72-303b-11e7-9b49-09741dcb6aad.png)

...rather than this...

![image](https://cloud.githubusercontent.com/assets/542937/25686338/750d4926-303b-11e7-9617-18205c723461.png)