### PR TITLE
Fix duplicated `at` propeties in Project

### DIFF
--- a/chapters/projects.md
+++ b/chapters/projects.md
@@ -12,7 +12,6 @@ Project has the following properties
 * billable: whether the project is billable or not (boolean, default true, available only for pro workspaces)
 * auto_estimates: whether the estimated hours are automatically calculated based on task estimations or manually fixed based on the value of 'estimated_hours' (boolean, default false, not required, premium functionality)
 * estimated_hours: if auto_estimates is true then the sum of task estimations is returned, otherwise user inserted hours (integer, not required, premium functionality)
-* at: timestamp that is sent in the response for PUT, indicates the time task was last updated (read-only)
 * color: id of the color selected for the project
 * rate: hourly rate of the project (float, not required, premium functionality)
 * at: timestamp indicating when the project was created (UTC time), read-only


### PR DESCRIPTION
Project chapter describes that there are two `at` properties:
> * at: timestamp that is sent in the response for PUT, indicates the time task was last updated (read-only)

and

> * at: timestamp indicating when the project was created (UTC time), read-only

But I think the first is the property for the task. (https://github.com/toggl/toggl_api_docs/blame/master/chapters/tasks.md#L12)
So it should not be here.

What do you think about it?