### PR TITLE
adds workspace ID to the docs

### DIFF
--- a/chapters/workspaces.md
+++ b/chapters/workspaces.md
@@ -2,6 +2,8 @@ Workspaces
 ====================
 
 Workspace has the following properties
+
+* id: the id of the workspace (integer). This ID is globally unique.
 * name: the name of the workspace (string)
 * premium: If it's a pro workspace or not. Shows if someone is paying for the workspace or not (boolean)
 * admin: shows whether currently requesting user has admin access to the workspace (boolean)


### PR DESCRIPTION
I was hacking along on a small reporting script, when I noticed that the workspace docs are missing information about the ID itself. Projects, Tasks and Clients have info about their uniqueness in the docs. Workspaces don't.

I then contacted your support, which swiftly informed me:

> 
> Hey Luis! You've certainly come to the right place for getting some answers :)
> 
> Yes, Workspace IDs are unique. 
> 

So this is the change to the docs to reflect that :-)

Hope that's ok! 