### PR TITLE
fix: new API urls

### DIFF
--- a/chapters/authentication.md
+++ b/chapters/authentication.md
@@ -17,7 +17,7 @@ If authentication fails, HTTP status code 403 is returned.
 
 Example request ([See also chapter about getting detailed user data](users.md))
 ```shell
-curl -v -u john.doe@gmail.com:secret -X GET https://www.toggl.com/api/v8/me
+curl -v -u john.doe@gmail.com:secret -X GET https://track.toggl.com/api/v8/me
 
 ```
 
@@ -39,7 +39,7 @@ Response
 		"beginning_of_week":1,
 		"language":"en_US",
 		"duration_format": "improved",
-		"image_url":"https://www.toggl.com/images/profile.png",
+		"image_url":"https://track.toggl.com/images/profile.png",
 		"at": "2015-02-17T16:58:53+00:00",
     		"created_at": "2014-07-31T07:51:17+00:00",
     		"timezone": "Europe/London",
@@ -88,7 +88,7 @@ When using Basic Auth and API token, use the API token as username and string "a
 
 Example request
 ```shell
-curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X GET https://www.toggl.com/api/v8/me
+curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X GET https://track.toggl.com/api/v8/me
 ```
 
 Response
@@ -108,7 +108,7 @@ Response
 		"store_start_and_stop_time":true,
 		"beginning_of_week":1,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/images/profile.png",
+		"image_url":"https://track.toggl.com/images/profile.png",
 		"new_blog_post":{},
 		"projects": [],
 		"tags": [],
@@ -126,14 +126,14 @@ Response
 
 ## Authentication with a session cookie
 
-`POST https://www.toggl.com/api/v8/sessions`
+`POST https://track.toggl.com/api/v8/sessions`
 
 It's possible to create a session. The session creation request sets a cookie in the response header `__Host-timer-session`, which you can use for authentication in all the API requests.
 
 Example request
 
 ```shell
-curl --data="" -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X POST https://www.toggl.com/api/v8/sessions
+curl --data="" -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X POST https://track.toggl.com/api/v8/sessions
 ```
 
 Successful response header includes the cookie
@@ -159,7 +159,7 @@ And body contains user's data
 		"store_start_and_stop_time":true,
 		"beginning_of_week":0,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
+		"image_url":"https://track.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
 		"sidebar_piechart":false,
 		"at":"2013-03-06T12:18:42+00:00",
 		"retention":9,
@@ -177,12 +177,12 @@ And body contains user's data
 
 Destroy the session manually by sending an according request to the API.
 
-`DELETE https://www.toggl.com/api/v8/sessions`
+`DELETE https://track.toggl.com/api/v8/sessions`
 
 Example request
 
 ```shell
-curl -v --cookie __Host-timer-session=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA== -X DELETE https://www.toggl.com/api/v8/sessions
+curl -v --cookie __Host-timer-session=MTM2MzA4MJa8jA3OHxEdi1CQkFFQ180SUFBUkFCRUFBQVlQLUNBQUVHYzNSeWFXNW5EQXdBQ25ObGMzTnBiMjVmYVdRR2MzUnlhVzVuREQ0QVBIUnZaMmRzTFdGd2FTMXpaWE56YVc5dUxUSXRaalU1WmpaalpEUTVOV1ZsTVRoaE1UaGhaalpqWkRkbU5XWTJNV0psWVRnd09EWmlPVEV3WkE9PXweAkG7kI6NBG-iqvhNn1MSDhkz2Pz_UYTzdBvZjCaA== -X DELETE https://track.toggl.com/api/v8/sessions
 ```
 
 Successful request will return `200 OK`.

--- a/chapters/clients.md
+++ b/chapters/clients.md
@@ -9,7 +9,7 @@ Client has the following properties
 
 ## Create a client
 
-`POST https://www.toggl.com/api/v8/clients`
+`POST https://track.toggl.com/api/v8/clients`
 
 Example request
 
@@ -17,7 +17,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"client":{"name":"Very Big Company","wid":777}}' \
-	-X POST https://www.toggl.com/api/v8/clients
+	-X POST https://track.toggl.com/api/v8/clients
 
 ```
 
@@ -35,13 +35,13 @@ Successful response
 
 ## Get client details
 
-`GET https://www.toggl.com/api/v8/clients/{client_id}`
+`GET https://track.toggl.com/api/v8/clients/{client_id}`
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/clients/1239455
+	-X GET https://track.toggl.com/api/v8/clients/1239455
 
 ```
 
@@ -59,7 +59,7 @@ Successful response
 ```
 
 ## Update a client
-`PUT https://www.toggl.com/api/v8/clients/{client_id}`
+`PUT https://track.toggl.com/api/v8/clients/{client_id}`
 
 Workspace id (wid) can't be changed.
 
@@ -68,7 +68,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"client":{"name":"Very Big Company","notes":"something about the client"}}' \
-	-X PUT https://www.toggl.com/api/v8/clients/1239455
+	-X PUT https://track.toggl.com/api/v8/clients/1239455
 ```
 
 Successful response
@@ -86,12 +86,12 @@ Successful response
 
 ## Delete a client
 
-`DELETE https://www.toggl.com/api/v8/clients/{client_id}`
+`DELETE https://track.toggl.com/api/v8/clients/{client_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/clients/1239455
+	-X DELETE https://track.toggl.com/api/v8/clients/1239455
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
@@ -104,12 +104,12 @@ Retrieving workspace clients is documented [here](workspaces.md#get-workspace-cl
 
 ## Get clients visible to user
 
-`GET https://www.toggl.com/api/v8/clients`
+`GET https://track.toggl.com/api/v8/clients`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/clients
+	-X GET https://track.toggl.com/api/v8/clients
 ```
 
 Successful response is an array of clients
@@ -133,12 +133,12 @@ Successful response is an array of clients
 
 ## Get client projects
 
-`GET https://www.toggl.com/api/v8/clients/{client_id}/projects`
+`GET https://track.toggl.com/api/v8/clients/{client_id}/projects`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/clients/1239455/projects
+	-X GET https://track.toggl.com/api/v8/clients/1239455/projects
 ```
 
 To filter projects by their state you can add the additional param to the request url:

--- a/chapters/cors.md
+++ b/chapters/cors.md
@@ -17,7 +17,7 @@ Record id (id) can't be changed on update.
 ## Actions
 ### Create an entry
 
-`POST https://www.toggl.com/api/v9/me/cors`
+`POST https://track.toggl.com/api/v9/me/cors`
 
 Example request
 
@@ -25,7 +25,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"domain":"url.com"}' \
-	-X POST https://www.toggl.com/api/v9/me/cors
+	-X POST https://track.toggl.com/api/v9/me/cors
 
 ```
 
@@ -40,13 +40,13 @@ Successful response
 
 ### Get entries for current user
 
-`GET https://www.toggl.com/api/v9/me/cors`
+`GET https://track.toggl.com/api/v9/me/cors`
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v9/me/cors
+	-X GET https://track.toggl.com/api/v9/me/cors
 ```
 
 Successful response
@@ -72,12 +72,12 @@ Successful response
 
 ### Delete an entry
 
-`DELETE https://www.toggl.com/api/v9/me/cors/{id}`
+`DELETE https://track.toggl.com/api/v9/me/cors/{id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v9/me/cors/1335076912
+	-X DELETE https://track.toggl.com/api/v9/me/cors/1335076912
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`

--- a/chapters/dashboard.md
+++ b/chapters/dashboard.md
@@ -22,12 +22,12 @@ Most active user object has the following properties
 
 ## Get Dashboard data
 
-`GET https://www.toggl.com/api/v8/dashboard/{workspace_id}`
+`GET https://track.toggl.com/api/v8/dashboard/{workspace_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/dashboard/3134975
+-X GET https://track.toggl.com/api/v8/dashboard/3134975
 ```
 
 Successful response

--- a/chapters/groups.md
+++ b/chapters/groups.md
@@ -8,7 +8,7 @@ Group has the following properties
 
 ## Create a group
 
-`POST https://www.toggl.com/api/v8/groups`
+`POST https://track.toggl.com/api/v8/groups`
 
 Example request
 
@@ -16,7 +16,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"group":{"name":"Developers","wid":777}}' \
-	-X POST https://www.toggl.com/api/v8/groups
+	-X POST https://track.toggl.com/api/v8/groups
 
 ```
 
@@ -33,7 +33,7 @@ Successful response
 ```
 
 ## Update a group
-`PUT https://www.toggl.com/api/v8/groups/{group_id}`
+`PUT https://track.toggl.com/api/v8/groups/{group_id}`
 
 Workspace id (wid) can't be changed.
 
@@ -42,7 +42,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"group":{"name":"Front-end Developers"}}' \
-	-X PUT https://www.toggl.com/api/v8/groups/1239455
+	-X PUT https://track.toggl.com/api/v8/groups/1239455
 ```
 
 Successful response
@@ -59,12 +59,12 @@ Successful response
 
 ## Delete a group
 
-`DELETE https://www.toggl.com/api/v8/groups/{group_id}`
+`DELETE https://track.toggl.com/api/v8/groups/{group_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/groups/1239455
+	-X DELETE https://track.toggl.com/api/v8/groups/1239455
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`

--- a/chapters/project_users.md
+++ b/chapters/project_users.md
@@ -21,7 +21,7 @@ It's possible to get user's fullname. For that you have to send the `fields` par
 
 ### Create a project user
 
-`POST https://www.toggl.com/api/v8/project_users`
+`POST https://track.toggl.com/api/v8/project_users`
 
 Example request
 
@@ -29,7 +29,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"project_user":{"pid":777,"uid":123,"rate":4.0,"manager":true}}' \
-	-X POST https://www.toggl.com/api/v8/project_users
+	-X POST https://track.toggl.com/api/v8/project_users
 
 ```
 
@@ -51,7 +51,7 @@ Successful response
 
 ### Update a project user
 
-`PUT https://www.toggl.com/api/v8/project_users/{project_user_id}`
+`PUT https://track.toggl.com/api/v8/project_users/{project_user_id}`
 
 Workspace id (wid), project id (pid) and user id (uid) can't be changed.
 
@@ -60,7 +60,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"project_user":{"manager":false,"rate":15,"fields":"fullname"}}' \
-	-X PUT https://www.toggl.com/api/v8/project_users/4692190
+	-X PUT https://track.toggl.com/api/v8/project_users/4692190
 ```
 
 Successful response
@@ -81,12 +81,12 @@ Successful response
 
 ### Delete a project user
 
-`DELETE https://www.toggl.com/api/v8/project_users/{project_user_id}`
+`DELETE https://track.toggl.com/api/v8/project_users/{project_user_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/project_users/4692190
+	-X DELETE https://track.toggl.com/api/v8/project_users/4692190
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
@@ -96,7 +96,7 @@ Successful request will return `200 OK`. If the user has no access to delete, yo
 
 ### Get list of project users in a Workspace
 ```shell
-curl -v -u TOKEN:api_token https://www.toggl.com/api/v8/workspaces/{workspace_id}/project_users
+curl -v -u TOKEN:api_token https://track.toggl.com/api/v8/workspaces/{workspace_id}/project_users
 ```
 
 Successful request will return a list of all project users in the workspace.
@@ -105,7 +105,7 @@ Note: Does not support the `fields` parameter (hence a `fullname` field won't be
 ### Create multiple project users for single project
 To create multiple project users for a single project, you must add multiple user ids separated with a comma with the `uid` parameter.
 
-`POST https://www.toggl.com/api/v8/project_users`
+`POST https://track.toggl.com/api/v8/project_users`
 
 Example request
 
@@ -113,7 +113,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"project_user":{"pid":777,"uid":"1267998,29624,112047","rate":4.0,"manager":true,"fields":"fullname"}}' \
-	-X POST https://www.toggl.com/api/v8/project_users
+	-X POST https://track.toggl.com/api/v8/project_users
 
 ```
 
@@ -151,7 +151,7 @@ Successful response is an array of project_users.
 ### Mass update for project users
 
 By supplying multiple project user ids, you can mass update project users.
-`PUT https://www.toggl.com/api/v8/project_users/{project_user_ids}`
+`PUT https://track.toggl.com/api/v8/project_users/{project_user_ids}`
 
 
 Example request
@@ -159,7 +159,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"project_user":{"manager":false,"rate":15,"fields":"fullname"}}' \
-	-X PUT https://www.toggl.com/api/v8/project_users/4692190,4692192,4692191
+	-X PUT https://track.toggl.com/api/v8/project_users/4692190,4692192,4692191
 ```
 
 Successful response is an array of project_users.
@@ -198,12 +198,12 @@ Successful response is an array of project_users.
 ### Delete multiple project users
 
 By supplying multiple project user ids, you can mass delete project users.
-`DELETE https://www.toggl.com/api/v8/project_users/{project_user_ids}`
+`DELETE https://track.toggl.com/api/v8/project_users/{project_user_ids}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/project_users/4692190,4692192,4692193
+	-X DELETE https://track.toggl.com/api/v8/project_users/4692190,4692192,4692193
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`

--- a/chapters/projects.md
+++ b/chapters/projects.md
@@ -20,7 +20,7 @@ Project has the following properties
 
 ## Create project
 
-`POST https://www.toggl.com/api/v8/projects`
+`POST https://track.toggl.com/api/v8/projects`
 
 Example request
 
@@ -28,7 +28,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"project":{"name":"An awesome project","wid":777,"template_id":10237,"is_private":true,"cid":123397}}' \
-	-X POST https://www.toggl.com/api/v8/projects
+	-X POST https://track.toggl.com/api/v8/projects
 ```
 
 Successful response
@@ -51,13 +51,13 @@ Successful response
 
 ## Get project data
 
-`GET https://www.toggl.com/api/v8/projects/{project_id}`
+`GET https://track.toggl.com/api/v8/projects/{project_id}`
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/projects/193838628
+	-X GET https://track.toggl.com/api/v8/projects/193838628
 
 ```
 
@@ -81,7 +81,7 @@ Successful response
 
 ## Update project data
 
-`PUT https://www.toggl.com/api/v8/projects/{project_id}`
+`PUT https://track.toggl.com/api/v8/projects/{project_id}`
 
 Example request
 
@@ -89,7 +89,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"project":{"name":"Changed the name","is_private":false,"cid":123398, "color": "6"}}' \
-	-X PUT https://www.toggl.com/api/v8/projects/193838628
+	-X PUT https://track.toggl.com/api/v8/projects/193838628
 ```
 
 
@@ -112,24 +112,24 @@ Successful response
 
 ## Delete a project
 
-`DELETE https://www.toggl.com/api/v8/projects/{project_id}`
+`DELETE https://track.toggl.com/api/v8/projects/{project_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/projects/4692190
+	-X DELETE https://track.toggl.com/api/v8/projects/4692190
 ```
 
 ## Get project users
 
-`GET https://www.toggl.com/api/v8/projects/{project_id}/project_users`
+`GET https://track.toggl.com/api/v8/projects/{project_id}/project_users`
 Read more about project user fields from [here](project_users.md).
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/projects/193838628/project_users
+	-X GET https://track.toggl.com/api/v8/projects/193838628/project_users
 
 ```
 
@@ -158,14 +158,14 @@ Successful response is an array of the project's users
 ## Get project tasks
 Available for Starter, Premium and Enterprise workspaces
 
-`GET https://www.toggl.com/api/v8/projects/{project_id}/tasks`
+`GET https://track.toggl.com/api/v8/projects/{project_id}/tasks`
 Read more about task fields from [here](tasks.md).
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/projects/777/tasks
+	-X GET https://track.toggl.com/api/v8/projects/777/tasks
 
 ```
 
@@ -202,10 +202,10 @@ Retrieving workspace projects is documented [here](workspaces.md#get-workspace-p
 ### Delete multiple projects
 
 By supplying multiple projectuser ids, you can mass delete projects.
-`DELETE https://www.toggl.com/api/v8/projects/{project_ids}`
+`DELETE https://track.toggl.com/api/v8/projects/{project_ids}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/projects/4692190,4692192,4692193
+	-X DELETE https://track.toggl.com/api/v8/projects/4692190,4692192,4692193
 ```

--- a/chapters/tags.md
+++ b/chapters/tags.md
@@ -7,7 +7,7 @@ Tag has the following properties
 
 ## Create tag
 
-`POST https://www.toggl.com/api/v8/tags`
+`POST https://track.toggl.com/api/v8/tags`
 
 Example request
 
@@ -15,7 +15,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"tag":{"name":"billed","wid":777}}' \
-	-X POST https://www.toggl.com/api/v8/tags
+	-X POST https://track.toggl.com/api/v8/tags
 
 ```
 
@@ -31,7 +31,7 @@ Successful response
 ```
 
 ## Update a tag
-`PUT https://www.toggl.com/api/v8/tags/{tag_id}`
+`PUT https://track.toggl.com/api/v8/tags/{tag_id}`
 
 Workspace id (wid) can't be changed.
 
@@ -40,7 +40,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"tag":{"name":"not billed"}}' \
-	-X PUT https://www.toggl.com/api/v8/tags/1239455
+	-X PUT https://track.toggl.com/api/v8/tags/1239455
 ```
 
 Successful response
@@ -56,12 +56,12 @@ Successful response
 
 ## Delete a tag
 
-`DELETE https://www.toggl.com/api/v8/tags/{tag_id}`
+`DELETE https://track.toggl.com/api/v8/tags/{tag_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/tags/1239455
+	-X DELETE https://track.toggl.com/api/v8/tags/1239455
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`

--- a/chapters/tasks.md
+++ b/chapters/tasks.md
@@ -17,7 +17,7 @@ Workspace id (wid) and project id (pid) can't be changed on update.
 ## Actions for single project user
 ### Create a task
 
-`POST https://www.toggl.com/api/v8/tasks`
+`POST https://track.toggl.com/api/v8/tasks`
 
 Example request
 
@@ -25,7 +25,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"task":{"name":"A new task","pid":777}}' \
-	-X POST https://www.toggl.com/api/v8/tasks
+	-X POST https://track.toggl.com/api/v8/tasks
 
 ```
 
@@ -45,13 +45,13 @@ Successful response
 
 ### Get task details
 
-`GET https://www.toggl.com/api/v8/tasks/{task_id}`
+`GET https://track.toggl.com/api/v8/tasks/{task_id}`
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET https://www.toggl.com/api/v8/tasks/1335076912
+	-X GET https://track.toggl.com/api/v8/tasks/1335076912
 ```
 
 Successful response
@@ -70,14 +70,14 @@ Successful response
 
 ### Update a task
 
-`PUT https://www.toggl.com/api/v8/tasks/{task_id}`
+`PUT https://track.toggl.com/api/v8/tasks/{task_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"task":{"active":false,"estimated_seconds":3600,"fields":"done_seconds,uname"}}' \
-	-X PUT https://www.toggl.com/api/v8/tasks/1335076912
+	-X PUT https://track.toggl.com/api/v8/tasks/1335076912
 ```
 
 Successful response
@@ -99,12 +99,12 @@ Successful response
 
 ### Delete a task
 
-`DELETE https://www.toggl.com/api/v8/tasks/{task_id}`
+`DELETE https://track.toggl.com/api/v8/tasks/{task_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/tasks/1335076912
+	-X DELETE https://track.toggl.com/api/v8/tasks/1335076912
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
@@ -115,14 +115,14 @@ Successful request will return `200 OK`. If the user has no access to delete, yo
 
 By supplying multiple task ids, you can mass update tasks. This is good for marking tasks as done or not done (`active`).
 
-`PUT https://www.toggl.com/api/v8/tasks/{task_ids}`
+`PUT https://track.toggl.com/api/v8/tasks/{task_ids}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"task":{"active":false,"fields":"done_seconds,uname"}}' \
-	-X PUT https://www.toggl.com/api/v8/tasks/1335076912,1335076911
+	-X PUT https://track.toggl.com/api/v8/tasks/1335076912,1335076911
 ```
 
 Successful response is an array of tasks.
@@ -155,12 +155,12 @@ Successful response is an array of tasks.
 
 ### Delete multiple tasks
 By supplying multiple task ids, you can mass delete tasks.
-`DELETE https://www.toggl.com/api/v8/tasks/{task_ids}`
+`DELETE https://track.toggl.com/api/v8/tasks/{task_ids}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/tasks/1335076912,1335076911,1335076910
+	-X DELETE https://track.toggl.com/api/v8/tasks/1335076912,1335076911,1335076910
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`

--- a/chapters/time_entries.md
+++ b/chapters/time_entries.md
@@ -19,7 +19,7 @@ Time entry has the following properties
 
 ## Create a time entry
 
-`POST https://www.toggl.com/api/v8/time_entries`
+`POST https://track.toggl.com/api/v8/time_entries`
 
 Example request
 
@@ -27,7 +27,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"time_entry":{"description":"Meeting with possible clients","tags":["billed"],"duration":1200,"start":"2013-03-05T07:58:58.000Z","pid":123,"created_with":"curl"}}' \
-	-X POST https://www.toggl.com/api/v8/time_entries
+	-X POST https://track.toggl.com/api/v8/time_entries
 
 ```
 
@@ -50,7 +50,7 @@ Successful response
 
 ## Start a time entry
 
-`POST https://www.toggl.com/api/v8/time_entries/start`
+`POST https://track.toggl.com/api/v8/time_entries/start`
 
 Example request
 
@@ -58,7 +58,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"time_entry":{"description":"Meeting with possible clients","tags":["billed"],"pid":123,"created_with":"curl"}}' \
-	-X POST https://www.toggl.com/api/v8/time_entries/start
+	-X POST https://track.toggl.com/api/v8/time_entries/start
 
 ```
 
@@ -81,13 +81,13 @@ Successful response
 
 ## Stop a time entry
 
-`PUT https://www.toggl.com/api/v8/time_entries/{time_entry_id}/stop`
+`PUT https://track.toggl.com/api/v8/time_entries/{time_entry_id}/stop`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
-	-X PUT https://www.toggl.com/api/v8/time_entries/436694100/stop
+	-X PUT https://track.toggl.com/api/v8/time_entries/436694100/stop
 ```
 
 Successful response
@@ -109,13 +109,13 @@ Successful response
 
 ## Get time entry details
 
-`GET https://www.toggl.com/api/v8/time_entries/{time_entry_id}`
+`GET https://track.toggl.com/api/v8/time_entries/{time_entry_id}`
 
 Example request:
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/time_entries/436694100
+-X GET https://track.toggl.com/api/v8/time_entries/436694100
 ```
 
 Successful response
@@ -140,13 +140,13 @@ Successful response
 
 ## Get running time entry
 
-`GET https://www.toggl.com/api/v8/time_entries/current`
+`GET https://track.toggl.com/api/v8/time_entries/current`
 
 Example request:
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/time_entries/current
+-X GET https://track.toggl.com/api/v8/time_entries/current
 ```
 
 Successful response
@@ -167,7 +167,7 @@ Successful response
 
 
 ## Update a time entry
-`PUT https://www.toggl.com/api/v8/time_entries/{time_entry_id}`
+`PUT https://track.toggl.com/api/v8/time_entries/{time_entry_id}`
 
 Example request
 
@@ -175,7 +175,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"time_entry":{"description":"Meeting with possible clients","tags":[""],"duration":1240,"start":"2013-03-05T07:58:58.000Z","stop":"2013-03-05T08:58:58.000Z","duronly":true,"pid":123,"billable":true}}' \
-	-X PUT https://www.toggl.com/api/v8/time_entries/436694100
+	-X PUT https://track.toggl.com/api/v8/time_entries/436694100
 
 ```
 
@@ -201,12 +201,12 @@ Successful response
 ## Delete a time entry
 
 
-`DELETE https://www.toggl.com/api/v8/time_entries/{time_entry_id}`
+`DELETE https://track.toggl.com/api/v8/time_entries/{time_entry_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/time_entries/1239455
+	-X DELETE https://track.toggl.com/api/v8/time_entries/1239455
 ```
 
 Successful request will return `200 OK`
@@ -214,7 +214,7 @@ Successful request will return `200 OK`
 
 ## Get time entries started in a specific time range
 
-`GET https://www.toggl.com/api/v8/time_entries`
+`GET https://track.toggl.com/api/v8/time_entries`
 
 With `start_date` and `end_date` parameters you can specify the date range of the time entries returned. If `start_date` and `end_date` are not specified, time entries started during the last 9 days are returned. **The limit of returned time entries is 1000.** So only the first 1000 found time entries are returned. To get all time entries for a specific time span, you should consider using the [detailed report](../reports/detailed.md) request, which returns paginated results, but enables you to get all the asked time entries with multiple requests.
 
@@ -224,7 +224,7 @@ Example request with start date 2013-03-10T15:42:46+02:00 and end_date 2013-03-1
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X GET "https://www.toggl.com/api/v8/time_entries?start_date=2013-03-10T15%3A42%3A46%2B02%3A00&end_date=2013-03-12T15%3A42%3A46%2B02%3A00"
+	-X GET "https://track.toggl.com/api/v8/time_entries?start_date=2013-03-10T15%3A42%3A46%2B02%3A00&end_date=2013-03-12T15%3A42%3A46%2B02%3A00"
 ```
 
 Successful response
@@ -257,7 +257,7 @@ Successful response
 
 ## Bulk update time entries tags ##
 
-`PUT https://www.toggl.com/api/v8/time_entries/{time_entry_ids_separated_by_a_comma}`
+`PUT https://track.toggl.com/api/v8/time_entries/{time_entry_ids_separated_by_a_comma}`
 
 You can mass assign and remove tags from time entries. Just instead of one `time_entry_id`, you need to send all the time entry ids, which you want to update, separated by a comma in the request url.
 The request is similar to regular time entry update.
@@ -274,7 +274,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"time_entry":{"tags":["billed","productive"], "tag_action": "add"}}' \
-	-X PUT https://www.toggl.com/api/v8/time_entries/436694100,436694101
+	-X PUT https://track.toggl.com/api/v8/time_entries/436694100,436694101
 ```
 
 Successful response

--- a/chapters/users.md
+++ b/chapters/users.md
@@ -24,7 +24,7 @@ User has the following properties
 * timezone: (string) timezone user has set on the "My profile" page ( [IANA TZ timezones](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones) )
 
 ## Get current user data ##
-`GET https://www.toggl.com/api/v8/me`
+`GET https://track.toggl.com/api/v8/me`
 
 By default the request responds with user properties.
 To get all the workspaces, clients, projects, tasks, time entries and tags which the user can see, add the parameter `with_related_data=true`
@@ -33,7 +33,7 @@ If you want to retrieve objects which have changed after certain time, add `sinc
 Example request *without* related data
 
 ```shell
-curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X GET https://www.toggl.com/api/v8/me
+curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X GET https://track.toggl.com/api/v8/me
 ```
 
 Successful response
@@ -53,7 +53,7 @@ Successful response
 		"store_start_and_stop_time":true,
 		"beginning_of_week":0,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
+		"image_url":"https://track.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
 		"sidebar_piechart":false,
 		"at":"2013-03-06T12:18:42+00:00",
 		"retention":9,
@@ -70,7 +70,7 @@ Successful response
 Example request with all the connected data
 
 ```shell
-curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X GET https://www.toggl.com/api/v8/me?with_related_data=true
+curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token -X GET https://track.toggl.com/api/v8/me?with_related_data=true
 ```
 
 Successful response
@@ -90,7 +90,7 @@ Successful response
 		"store_start_and_stop_time":true,
 		"beginning_of_week":0,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
+		"image_url":"https://track.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
 		"sidebar_piechart":false,
 		"at":"2013-03-06T12:18:42+00:00",
 		"retention":9,
@@ -164,7 +164,7 @@ Successful response
 
 ## Update user data ##
 
-`PUT https://www.toggl.com/api/v8/me`
+`PUT https://track.toggl.com/api/v8/me`
 
 You can update the following user fields:
 * fullname: string
@@ -190,7 +190,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"user":{"fullname":"John Smith"}}' \
-	-X PUT https://www.toggl.com/api/v8/me
+	-X PUT https://track.toggl.com/api/v8/me
 ```
 
 Successful response
@@ -210,7 +210,7 @@ Successful response
 		"store_start_and_stop_time":true,
 		"beginning_of_week":1,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
+		"image_url":"https://track.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png",
 		"sidebar_piechart":false,
 		"at":"2013-08-12T11:55:58+03:00",
 		"retention":9,
@@ -230,13 +230,13 @@ Successful response
 ```
 
 ## Reset API token ##
-`POST https://www.toggl.com/api/v8/reset_token`
+`POST https://track.toggl.com/api/v8/reset_token`
 
 Example request
 
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X POST https://www.toggl.com/api/v8/reset_token
+	-X POST https://track.toggl.com/api/v8/reset_token
 ```
 
 Successful response is a string with the new API token: 
@@ -257,13 +257,13 @@ To create a user you must provide these parameters for the user:
 * timezone: for example "Etc/UTC" (string, required)
 * created_with: in free form, name of the app that signed the user app (string, required)
 
-`POST https://www.toggl.com/api/v8/signups`
+`POST https://track.toggl.com/api/v8/signups`
 
 Example request
 ```shell
 curl -H "Content-Type: application/json" \
 -d '{"user":{"email":"test.user@toggl.com","password":"StrongPassword"}}' \
--X POST https://www.toggl.com/api/v8/signups
+-X POST https://track.toggl.com/api/v8/signups
 ```
 
 Successful response includes created user's data and API token

--- a/chapters/workspace_users.md
+++ b/chapters/workspace_users.md
@@ -12,7 +12,7 @@ Workspace user has the following properties:
 
 You can add users to workspace by email addresses. A letter inviting the user to your workspace is sent to the user's email.
 
-`POST https://www.toggl.com/api/v8/workspaces/{workspace_id}/invite`
+`POST https://track.toggl.com/api/v8/workspaces/{workspace_id}/invite`
 
 Request has the following properties:
 * emails: array of emails
@@ -28,7 +28,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"emails":["john.doe@toggl.com", "Jane.Swift@toggl.com"]}' \
-	-X POST https://www.toggl.com/api/v8/workspaces/777/invite
+	-X POST https://track.toggl.com/api/v8/workspaces/777/invite
 ```
 
 Successful response
@@ -52,7 +52,7 @@ Successful response
 
 Only the admin flag can be changed.
 
-`PUT https://www.toggl.com/api/v8/workspace_users/{workspace_user_id}`
+`PUT https://track.toggl.com/api/v8/workspace_users/{workspace_user_id}`
 
 Example request
 
@@ -60,7 +60,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"workspace_user":{"admin":false}}' \
-	-X PUT https://www.toggl.com/api/v8/workspace_users/19012628
+	-X PUT https://track.toggl.com/api/v8/workspace_users/19012628
 ```
 
 
@@ -79,12 +79,12 @@ Successful response
 
 ## Delete workspace user
 
-`DELETE https://www.toggl.com/api/v8/workspace_users/{workspace_user_id}`
+`DELETE https://track.toggl.com/api/v8/workspace_users/{workspace_user_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
-	-X DELETE https://www.toggl.com/api/v8/workspace_users/19012628
+	-X DELETE https://track.toggl.com/api/v8/workspace_users/19012628
 ```
 
 Successful request will return `200 OK`. If the user has no access to delete, you'll get a status code `4xx`
@@ -92,12 +92,12 @@ Successful request will return `200 OK`. If the user has no access to delete, yo
 ## Get workspace users
 
 This request returns not the user objects, but the `workspace_user` objects (the connection between user and workspace)
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/workspace_users`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/workspace_users`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/workspace_users
+-X GET https://track.toggl.com/api/v8/workspaces/777/workspace_users
 ```
 
 Successful response is an array of workspace's workspace users

--- a/chapters/workspaces.md
+++ b/chapters/workspaces.md
@@ -24,13 +24,13 @@ Workspace has the following properties
 
 ## Get workspaces
 
-`GET https://www.toggl.com/api/v8/workspaces`
+`GET https://track.toggl.com/api/v8/workspaces`
 Get data about all the workspaces where the token owner belongs to.
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces
+-X GET https://track.toggl.com/api/v8/workspaces
 ```
 
 Successful response is an array of workspaces
@@ -66,12 +66,12 @@ Successful response is an array of workspaces
 ```
 
 ## Get single workspace
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/3134975
+-X GET https://track.toggl.com/api/v8/workspaces/3134975
 ```
 
 Successful response
@@ -96,7 +96,7 @@ Successful response
 
 ## Update workspace
 
-`PUT https://www.toggl.com/api/v8/workspaces/{workspace_id}`
+`PUT https://track.toggl.com/api/v8/workspaces/{workspace_id}`
 
 Example request
 
@@ -105,7 +105,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"workspace":{"default_currency": "EUR", "default_hourly_rate": 50, "name": "John's ws", "only_admins_may_create_projects": false, "only_admins_see_billable_rates": true, "rounding": 1, "rounding_minutes": 60}}' \
-	-X PUT https://www.toggl.com/api/v8/workspaces/3134975
+	-X PUT https://track.toggl.com/api/v8/workspaces/3134975
 ```
 
 
@@ -132,12 +132,12 @@ Successful response
 ## Get workspace users
 
 To get a successful response, the token owner must be workspace admin.
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/users`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/users`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/users
+-X GET https://track.toggl.com/api/v8/workspaces/777/users
 ```
 
 Successful response is an array of workspace users
@@ -155,7 +155,7 @@ Successful response is an array of workspace users
 		"store_start_and_stop_time":true,
 		"beginning_of_week":0,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/system/avatars/123123/small/open-uri20121116-2767-b1qr8l.png",
+		"image_url":"https://track.toggl.com/system/avatars/123123/small/open-uri20121116-2767-b1qr8l.png",
 		"sidebar_piechart":false,
 		"at":"2013-03-06T08:57:12+00:00",
 		"retention":9,
@@ -177,7 +177,7 @@ Successful response is an array of workspace users
 		"store_start_and_stop_time":true,
 		"beginning_of_week":1,
 		"language":"en_US",
-		"image_url":"https://www.toggl.com/images/profile.png",
+		"image_url":"https://track.toggl.com/images/profile.png",
 		"sidebar_piechart":false,
 		"at":"2013-03-06T08:46:07+00:00",
 		"created_at":"2013-03-06T07:52:03+00:00",
@@ -194,12 +194,12 @@ Successful response is an array of workspace users
 ## Get workspace clients
 
 To get a successful response, the token owner must be workspace admin.
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/clients`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/clients`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/clients
+-X GET https://track.toggl.com/api/v8/workspaces/777/clients
 ```
 
 Successful response is an array of workspace clients
@@ -228,12 +228,12 @@ Successful response is an array of workspace clients
 ## Get workspace groups
 
 To get a successful response, the token owner must be workspace admin.
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/groups`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/groups`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/groups
+-X GET https://track.toggl.com/api/v8/workspaces/777/groups
 ```
 
 Successful response is an array of workspace groups
@@ -256,7 +256,7 @@ Successful response is an array of workspace groups
 ## Get workspace projects
 
 To get a successful response, the token owner must be workspace admin.
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/projects`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/projects`
 
 To filter projects by their state you can add the additional param to the request url:
 * active: possible values `true`/`false`/`both`. By default true. If false, only archived projects are returned.
@@ -270,7 +270,7 @@ To get only project templates add the additional param to the request url:
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/projects
+-X GET https://track.toggl.com/api/v8/workspaces/777/projects
 ```
 
 Successful response is an array of active workspace projects
@@ -303,7 +303,7 @@ Successful response is an array of active workspace projects
 Available only for pro workspaces
 To get a successful response, the token owner must be workspace admin.
 Get all not done tasks in this workspace.
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/tasks`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/tasks`
 
 To filter tasks by their state you can add the additional param to the request url:
 * active: possible values `true`/`false`/`both`. By default true. If false, only done tasks are returned.
@@ -312,7 +312,7 @@ To filter tasks by their state you can add the additional param to the request u
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/tasks
+-X GET https://track.toggl.com/api/v8/workspaces/777/tasks
 ```
 
 Successful response is an array of workspace tasks
@@ -350,12 +350,12 @@ Successful response is an array of workspace tasks
 
 ## Get workspace tags
 
-`GET https://www.toggl.com/api/v8/workspaces/{workspace_id}/tags`
+`GET https://track.toggl.com/api/v8/workspaces/{workspace_id}/tags`
 
 Example request
 ```shell
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
--X GET https://www.toggl.com/api/v8/workspaces/777/tags
+-X GET https://track.toggl.com/api/v8/workspaces/777/tags
 ```
 
 Successful response is an array of active workspace tags

--- a/reports.md
+++ b/reports.md
@@ -1,7 +1,7 @@
 Toggl Reports API v2
 =================
 
-Here you can get the general information about how to use Toggl reports API, from how to authenticate, what filters to use and how the response is structured. The available reports are similar to the reports available in [Toggl reports page](https://www.toggl.com/app/reports).
+Here you can get the general information about how to use Toggl reports API, from how to authenticate, what filters to use and how the response is structured. The available reports are similar to the reports available in [Toggl reports page](https://track.toggl.com/app/reports).
 
 More detailed information for the reports.
 * [Weekly report](reports/weekly.md)
@@ -118,6 +118,6 @@ Example warning
     Warning:Human readable warning message
 
 There are two test endpoints, that return error so you can test client side 
-error handling: [Error 400](https://www.toggl.com/reports/api/v2/error400) and 
-[Error 500](https://www.toggl.com/reports/api/v2/error500) both of them set 
+error handling: [Error 400](https://track.toggl.com/reports/api/v2/error400) and 
+[Error 500](https://track.toggl.com/reports/api/v2/error500) both of them set 
 Warning header to test value.

--- a/reports/project.md
+++ b/reports/project.md
@@ -69,7 +69,7 @@ Project dashboard response has following strucure: ([json schema]
  
 request:
 ```shell
-curl -u my-secret-toggl-api-token:api_token -X GET "https://www.toggl.com/reports/api/v2/project/?page=1&user_agent=devteam@example.com&workspace_id=1&project_id=2"
+curl -u my-secret-toggl-api-token:api_token -X GET "https://track.toggl.com/reports/api/v2/project/?page=1&user_agent=devteam@example.com&workspace_id=1&project_id=2"
 ```
 
 response (formatted for readability):

--- a/toggl_api.md
+++ b/toggl_api.md
@@ -20,7 +20,7 @@ Example request
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H "Content-Type: application/json" \
 	-d '{"time_entry":{"description":"New time entry","created_with":"API example code","start":"2012-02-12T15:35:47+02:00","duration":1200,"wid":31366}}' \
-	 -X POST https://www.toggl.com/api/v8/time_entries
+	 -X POST https://track.toggl.com/api/v8/time_entries
 
 ```
 Response
@@ -51,7 +51,7 @@ If a create or update action failed, HTTP status code 404 and an array of locali
 curl -v -u 1971800d4d82861d8f2c1651fea4d212:api_token \
 	-H 'Content-Type: application/json' \
 	-d '{"time_entry":{"description":"New time entry","created_with":"API example code"}}' \
-	-X POST https://www.toggl.com/api/v8/time_entries
+	-X POST https://track.toggl.com/api/v8/time_entries
 ```
 
 Response


### PR DESCRIPTION
As a result of the rebranding you peeps just went trough :) 

Note: in some JSON responses there are images referenced. I also replaced the `www.` with a `track.` there, but I'm not quite sure that's correct.

Hope this helps in kicking off "rebranding" the API docs as well :) 