### PR TITLE
Update C++ open source lib reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Toggl API has moved to Github so you could actively participate in helping u
 
 ### C++
 
-* TogglDesktop has an [open source, cross platform library](https://github.com/toggl/toggldesktop/tree/master/src/lib) that can be reused in your own apps.
+* TogglDesktop has an [open source, cross platform library](https://github.com/toggl-open-source/toggldesktop/tree/master/src/lib) that can be reused in your own apps.
 
 ### .NET
 


### PR DESCRIPTION
The current [link](https://github.com/toggl/toggldesktop/tree/master/src/lib) sends to a not found page because it is referring to the [private toggldesktop](https://github.com/toggl/toggldesktop). We can update the link to the [toggl-open-source version](https://github.com/toggl-open-source/toggldesktop/tree/master/src/lib).