### PR TITLE
Remove reference to TogglAPI.Net project

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ The Toggl API has moved to Github so you could actively participate in helping u
 ### .NET
 
 * The Toggl mobile apps have [shared C# libraries](https://github.com/toggl/mobileapp) which provide access to the API and also common clientside business logic we use. Feel free to use as little or much of it as you want.
-* [Ilya Pirozhenko](https://github.com/sochix) has written a .NET library: https://www.nuget.org/packages/TogglAPI.Net/
 
 ### Scala
 * [Gabriele Alese](https://github.com/gabalese) has written a command line client for Toggl: https://github.com/gabalese/toggl-cli


### PR DESCRIPTION
closes toggl/backend#11428